### PR TITLE
Reduce recursion for unrelated templates parsing

### DIFF
--- a/src/witness.ts
+++ b/src/witness.ts
@@ -196,6 +196,15 @@ export function generateWitness(circJson: any): (input: any) => any {
     let currentComponent: string | undefined;
     let scopes: Scope[] = []; // scope stack
     const notInitSignals = {} as any;
+    // Queue of component indices ready to be triggered. Using a queue instead of
+    // direct recursion prevents stack overflow on deep inter-template chains (e.g.
+    // MontgomeryAdd in complex circuits).
+    const pendingComponents: any[] = [];
+    // Tracks how many triggerComponent frames are currently on the call stack.
+    // Used in setSignalFullName to decide whether a newly-ready component is a
+    // direct sub-component (safe to trigger synchronously) or an independent chain
+    // (must be deferred to pendingComponents).
+    let triggerDepth = 0;
 
     function inScope(newScope: Scope, cb: Function) {
       const oldScope = scopes;
@@ -212,8 +221,21 @@ export function generateWitness(circJson: any): (input: any) => any {
       const template = components[c].template;
       const newScope: any = {};
       for (let p in components[c].params) newScope[p] = components[c].params[p];
+      // Track depth so setSignalFullName can distinguish sub-component triggers
+      // (safe to recurse) from independent-chain triggers (must be deferred).
+      triggerDepth++;
       inScope(newScope, () => templates[template](ctx));
+      triggerDepth--;
       currentComponent = oldComponent;
+    }
+    // Process all deferred components until none remain. The notInitSignals guard
+    // (>= 0) skips duplicates: triggerComponent decrements to -1 on first call, so
+    // any component pushed twice will be a no-op on the second dequeue.
+    function drainPendingComponents() {
+      while (pendingComponents.length > 0) {
+        const c = pendingComponents.shift();
+        if (notInitSignals[c] >= 0) triggerComponent(c);
+      }
     }
     function setSignalFullName(fullName: any, value: any) {
       const sId = getSignalIdx(fullName);
@@ -227,8 +249,23 @@ export function generateWitness(circJson: any): (input: any) => any {
         callComponents.push(idCmp);
       }
       callComponents.map((c) => {
-        if (notInitSignals[c] == 0) triggerComponent(c);
+        if (notInitSignals[c] == 0) {
+          // Only trigger synchronously when we are inside a template AND the newly-ready
+          // component is a direct child of the current one (setPin→getPin sub-component
+          // pattern). All other ready components are deferred to the queue to avoid
+          // unbounded recursion across independent inter-template chains.
+          const isSubcomponent =
+            triggerDepth > 0 && components[c].name.startsWith(currentComponent + '.');
+          if (isSubcomponent) {
+            triggerComponent(c);
+          } else {
+            pendingComponents.push(c);
+          }
+        }
       });
+      // Drain at the top level (i.e. from input processing, not from within a template).
+      // Mirrors the drainPendingComponents() call after the input loop in snarkjs.
+      if (triggerDepth === 0) drainPendingComponents();
       return witness[sId];
     }
     function getSignalFullName(name: string) {
@@ -299,7 +336,11 @@ export function generateWitness(circJson: any): (input: any) => any {
       // Processing
       for (const c in components) notInitSignals[c] = components[c].inputSignals;
       ctx.setSignal('one', [], BigInt(1));
-      for (let c in notInitSignals) if (notInitSignals[c] == 0) triggerComponent(c);
+      // Queue all components that are already fully initialised (zero remaining inputs)
+      // and drain the queue iteratively rather than triggering them inline. This avoids
+      // a call-stack overflow when complex circuits have long inter-template chains.
+      for (let c in notInitSignals) if (notInitSignals[c] == 0) pendingComponents.push(c);
+      drainPendingComponents();
       // Circuit JSON inputs are own fields; prototypes may carry unrelated app metadata.
       for (const s of Object.keys(input)) {
         currentComponent = 'main';

--- a/test/helpers/chain-circuit.js
+++ b/test/helpers/chain-circuit.js
@@ -1,0 +1,79 @@
+/**
+ * Builds a synthetic circom-js circuit JSON that chains N "relay" components in series:
+ *
+ *   user input  →  main.c0  →  main.c1  →  …  →  main.c(N-1)  →  output
+ *
+ * Each component reads its `in` signal and immediately writes the same value to its
+ * `out` signal.  Adjacent components share a signal slot, so c(i).out and c(i+1).in
+ * are the same witness entry — setting it decrements c(i+1)'s uninitialized-input
+ * counter and, when that counter reaches zero, marks c(i+1) as ready to execute.
+ *
+ * Without the queue-based fix in generateWitness this produces a call stack N frames
+ * deep (triggerComponent → template → setSignal → triggerComponent → …), which
+ * overflows the JS engine for large N.  With the fix every component after the first
+ * is deferred to pendingComponents and processed iteratively.
+ *
+ * Signal slot layout
+ * ------------------
+ *  0          : "one"                           (constant 1)
+ *  1          : "main.out" / "main.c(N-1).out" (final output, written by last relay)
+ *  2          : "main.in"  / "main.c0.in"      (user-supplied input)
+ *  3..N+1     : shared intermediate slots c(i).out = c(i+1).in  for i = 0..N-2
+ */
+export function buildDeepChainCircuit(n) {
+  if (n < 1) throw new RangeError('n must be >= 1');
+
+  // ── signals ──────────────────────────────────────────────────────────────────
+  // Slot 0: constant one
+  const signals = [{ names: ['one'], triggerComponents: [] }];
+
+  // Slot 1: final output (shared name with c(N-1).out so the Relay template that
+  // executes as "main.c(N-1)" can reach it via ctx.setSignal("out", []))
+  signals.push({ names: ['main.out', `main.c${n - 1}.out`], triggerComponents: [] });
+
+  // Slot 2: user input (shared with c0.in so getSignal("in") inside c0 resolves here)
+  signals.push({ names: ['main.in', 'main.c0.in'], triggerComponents: [0] });
+
+  // Slots 3..N+1: one shared slot per adjacent pair c(i).out / c(i+1).in
+  for (let i = 0; i < n - 1; i++) {
+    signals.push({
+      names: [`main.c${i}.out`, `main.c${i + 1}.in`],
+      // Setting this slot means c(i+1) has received its only input → ready to run
+      triggerComponents: [i + 1],
+    });
+  }
+
+  // ── signalName2Idx ────────────────────────────────────────────────────────────
+  const signalName2Idx = {};
+  for (let s = 0; s < signals.length; s++) {
+    for (const name of signals[s].names) signalName2Idx[name] = s;
+  }
+
+  // ── components ───────────────────────────────────────────────────────────────
+  const components = [];
+  for (let i = 0; i < n; i++) {
+    components.push({ name: `main.c${i}`, template: 'Relay', inputSignals: 1, params: {} });
+  }
+
+  // ── template ─────────────────────────────────────────────────────────────────
+  // The Relay template passes its single input through to its output unchanged.
+  // getSignal("in") resolves to `currentComponent + ".in"` (e.g. "main.c0.in"),
+  // setSignal("out") resolves to `currentComponent + ".out"` (e.g. "main.c0.out").
+  const templates = {
+    Relay: `function(ctx) {
+      ctx.setSignal("out", [], ctx.getSignal("in", []));
+    }`,
+  };
+
+  return {
+    nVars: n + 2,     // one slot per signal
+    nInputs: 1,       // only "in"
+    nOutputs: 1,      // only "out" (slot 1, checked by generateWitness after inputIdx)
+    nSignals: n + 2,
+    signals,
+    components,
+    templates,
+    functions: {},
+    signalName2Idx,
+  };
+}

--- a/test/helpers/deep-chain-runner.js
+++ b/test/helpers/deep-chain-runner.js
@@ -1,0 +1,33 @@
+/**
+ * Subprocess entry point for the stack-overflow regression test.
+ *
+ * Run via:
+ *   node --stack-size=256 test/helpers/deep-chain-runner.js
+ *
+ * With --stack-size=256 (256 kB) the old synchronous-recursion approach inside
+ * generateWitness would crash with "Maximum call stack size exceeded" for N=1000
+ * components.  The queue-based drain introduced by the snarkjs patch handles this
+ * depth iteratively and must exit 0.
+ *
+ * Exit codes:
+ *   0  success — witness computed and output matched
+ *   1  unhandled exception (e.g. RangeError: Maximum call stack size exceeded)
+ *   2  wrong output value
+ */
+import { generateWitness } from '../../witness.js';
+import { buildDeepChainCircuit } from './chain-circuit.js';
+
+const N = 1000;
+const INPUT_VALUE = '7';
+
+const circuit = buildDeepChainCircuit(N);
+const result = generateWitness(circuit)({ in: INPUT_VALUE });
+
+// result[1] is the main.out slot — should equal the input value after passing
+// through all N relay components unchanged.
+if (result[1] !== BigInt(INPUT_VALUE)) {
+  process.stderr.write(`Wrong output: expected ${INPUT_VALUE}n, got ${result[1]}\n`);
+  process.exit(2);
+}
+
+process.exit(0);

--- a/test/witness.test.js
+++ b/test/witness.test.js
@@ -3,11 +3,13 @@ import { bn254 } from '@noble/curves/bn254.js';
 import { keccakprg } from '@noble/hashes/sha3-addons.js';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import { deepStrictEqual, throws } from 'node:assert';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { dirname, join as joinPath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import * as zkp from '../index.js';
 import * as witness from '../witness.js';
+import { buildDeepChainCircuit } from './helpers/chain-circuit.js';
 import sumCircuit from './vectors/sum-circuit.json' with { type: 'json' };
 import sumConstraints from './vectors/sum_test_constraints.json' with { type: 'json' };
 import { utf8ToBytes } from '@noble/hashes/utils.js';
@@ -296,6 +298,34 @@ describe('Witness', () => {
     });
     console.log('PROOF', JSON.stringify(zkp.stringBigints.encode(proof)));
     deepStrictEqual(groth16.verifyProof(vkey, proof), true);
+  });
+
+  // ── deep relay-chain tests ────────────────────────────────────────────────────
+  // These tests exercise the queue-based component-drain introduced to prevent
+  // call-stack overflow on circuits with long inter-template chains.
+
+  should('deep relay chain: correct output for small N', () => {
+    // Functional sanity check: a 10-component relay chain passes the input value
+    // through unchanged.  result[1] is the main.out slot.
+    const gen = witness.generateWitness(buildDeepChainCircuit(10));
+    deepStrictEqual(gen({ in: '42' })[1], 42n);
+  });
+
+  should('deep relay chain: no stack overflow under reduced stack size (N=1000, stack=256kB)', () => {
+    // Spawn a subprocess with --stack-size=256 (256 kB).  Under the old synchronous-
+    // recursion approach 1000 triggerComponent frames would exceed that budget and
+    // crash with "Maximum call stack size exceeded".  The queue-based drain must
+    // process all components iteratively and exit 0.
+    const result = spawnSync(
+      process.execPath,
+      ['--stack-size=256', joinPath(_dirname, 'helpers', 'deep-chain-runner.js')],
+      { timeout: 30_000, encoding: 'utf8' }
+    );
+    deepStrictEqual(
+      result.status,
+      0,
+      `Subprocess crashed (status ${result.status}):\n${result.stderr}`
+    );
   });
 });
 


### PR DESCRIPTION
When running from a browser environment we would hit `Maximum call stack size exceeded` for some big circuits. We removed unbounded recursion by introducing a deferred queue pattern.